### PR TITLE
wrapItem() didn't wrap objects properly

### DIFF
--- a/src/backend/utils/adt/jsonpath_exec.c
+++ b/src/backend/utils/adt/jsonpath_exec.c
@@ -2736,13 +2736,20 @@ wrapItem(JsonbValue *jbv)
 {
 	JsonbParseState *ps = NULL;
 	JsonbValue	jbvbuf;
-	int			type = JsonbType(jbv);
 
-	if (type == jbvArray)
-		return jbv;
-
-	if (type == jbvScalar)
-		jbv = JsonbExtractScalar(jbv->val.binary.data, &jbvbuf);
+	switch (JsonbType(jbv))
+	{
+		case jbvArray:
+			return jbv;
+		case jbvScalar:
+			jbv = JsonbExtractScalar(jbv->val.binary.data, &jbvbuf);
+			break;
+		case jbvObject:
+			jbv = JsonbWrapInBinary(jbv, &jbvbuf);
+			break;
+		default:
+			;
+	}
 
 	pushJsonbValue(&ps, WJB_BEGIN_ARRAY, NULL);
 	pushJsonbValue(&ps, WJB_ELEM, jbv);


### PR DESCRIPTION
jbv will be passed to pushJsonbValue() and from there to pushJsonbValueScalar(). The latter in assert-enabled builds insists that jbv is a scalar in case of WJB_ELEM which is intended for scalars that are wrapped between WJB_BEGIN_ARRAY and WJB_END_ARRAY. Therefore if jbv is an object, it needs to be wrapped in a binary form so that pushJsonbValue() will call pushJsonbValueScalar() with the right token (WJB_BEGIN_OBJECT).

This enables proper execution of queries like SELECT JSON_QUERY(jsonb '{}', '{"a":"b"}[*]') in assert-enabled builds. In non-assert-enabled builds it appears to have worked, but perhaps only by accident.

In this particular case, the wrapping is needed to implement the fact that the standard allows subscript path steps to be applied to non-arrays in lax mode. This should be documented somewhere, probably in form of a comment (perhaps right above wrapItem() definition), but I don't know yet if there are any other reasons for this kind of wrapping to happen so I don't want to write a comment which is potentially half-true.